### PR TITLE
Save relations in smarter way

### DIFF
--- a/cmd/malscraper/main.go
+++ b/cmd/malscraper/main.go
@@ -54,13 +54,14 @@ func main() {
 
 	active := make(chan bool, config.Scraper.MaxConcurrent)
 	go monitor(db, active, config.Scraper.MaxConcurrent)
-	go overseer(db, active, config.Scraper.MaxConcurrent)
 
 	// Maybe trigger first user?
 	var inDb *int
 	if db.Model(&core.User{}).Count(&inDb); *inDb == 0 {
 		scraper.GetOrCreateUser("sweetmonia", db)
 	}
+
+	go overseer(db, active, config.Scraper.MaxConcurrent)
 
 	// Don't quit
 	finished := make(chan bool)

--- a/scraper/fetch.go
+++ b/scraper/fetch.go
@@ -87,14 +87,15 @@ func GetUser(username string, db *gorm.DB, finished chan bool) {
 
 	friendsChannel := make(chan []string, 1)
 	go getFriends(friendsChannel, username, 0)
+	var relations []core.Relation
 	for friendsPage := range friendsChannel {
 		for i := range friendsPage {
 			friendName := friendsPage[i]
 			friend := GetOrCreateUser(friendName, db)
-			relation := core.NewRelation(user, friend)
-			db.Where(relation).FirstOrCreate(relation)
+			relations = append(relations, core.NewRelation(user, friend))
 		}
 	}
+	core.SaveRelations(db, relations)
 	user.Fetched = true
 	user.Fetching = false
 	db.Save(&user)


### PR DESCRIPTION
Lessen burden on the database by using only `INSERT ... ON CONFLICT DO NOTHING` queries, and batch multiple inserts into single query.